### PR TITLE
fix: without "intercept IO", log LSP to /dev/null

### DIFF
--- a/src/lsp/init.rs
+++ b/src/lsp/init.rs
@@ -40,7 +40,7 @@ pub(crate) async fn spawn_lsp(
                 .await,
         )
     } else {
-        Stdio::inherit()
+        Stdio::null()
     };
 
     let mut child = Command::new(quirks.language_server_binary())


### PR DESCRIPTION
Forwarding the LSP logs to the MCP stderr is both confusing for the user and may also overload the MCP host (e.g. claude code).