### PR TITLE
refactor: simplify test MCP shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,6 @@ dependencies = [
  "itertools",
  "lsp-client",
  "lsp-types",
- "nix 0.31.3",
  "predicates",
  "rmcp",
  "serde",
@@ -737,18 +736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +850,7 @@ checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
  "indexmap",
- "nix 0.30.1",
+ "nix",
  "tokio",
  "tracing",
  "windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 [dev-dependencies]
 assert_cmd = "2.2.2"
 insta = { version = "1.47.2", features = ["json"] }
-nix = { version = "0.31.3", features = ["process", "signal"] }
 predicates = "3.1.4"
 rmcp = { version = "0.8", features = ["client", "transport-child-process"] }
 tempfile = "3.27.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,6 @@ use assert_cmd as _;
 #[cfg(test)]
 use insta as _;
 #[cfg(test)]
-use nix as _;
-#[cfg(test)]
 use predicates as _;
 #[cfg(test)]
 use tempfile as _;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,7 +7,6 @@ use insta as _;
 use itertools as _;
 use lsp_client as _;
 use lsp_types as _;
-use nix as _;
 use rmcp as _;
 use serde as _;
 use serde_json as _;

--- a/tests/mcp/setup.rs
+++ b/tests/mcp/setup.rs
@@ -66,8 +66,6 @@ pub(crate) struct TestSetup {
 
     service: Option<RunningService<RoleClient, ()>>,
 
-    pid: u32,
-
     normalize_paths: bool,
 }
 
@@ -116,8 +114,6 @@ impl TestSetup {
             .spawn()
             .expect("spawn language server")
             .0;
-        let pid = child.id().expect("child id");
-
         let service = ().serve(child).await.expect("service start");
 
         Self {
@@ -125,7 +121,6 @@ impl TestSetup {
             intercept_io_dir,
             cwd,
             service: Some(service),
-            pid,
             normalize_paths: true,
         }
     }
@@ -216,23 +211,10 @@ impl TestSetup {
     }
 
     pub(crate) async fn shutdown(mut self) {
-        use nix::{
-            sys::signal::{Signal, kill},
-            unistd::Pid,
-        };
-
         // take service service BEFORE potentially panicking
         let service = self.service.take().expect("not shut down yet");
 
-        // there is no way to cleanly shutdown the server using the Rust MCP SDK yet, see https://github.com/modelcontextprotocol/rust-sdk/issues/347
-        let pid = Pid::from_raw(self.pid.try_into().expect("valid pid"));
-        tokio::task::spawn_blocking(move || {
-            kill(pid, Signal::SIGTERM).expect("can send signal");
-        })
-        .await
-        .expect("spawn blocking");
-
-        service.waiting().await.expect("wait for service to exit");
+        service.cancel().await.expect("shut down service");
     }
 }
 


### PR DESCRIPTION
Now that https://github.com/modelcontextprotocol/rust-sdk/issues/347 is fixed, we can simplify our code.